### PR TITLE
change default timeout configuration from 60s to 10s

### DIFF
--- a/lib/wrest/native/connection_factory.rb
+++ b/lib/wrest/native/connection_factory.rb
@@ -9,8 +9,8 @@
 
 module Wrest::Native
   module ConnectionFactory
-    def create_connection(options = {:timeout => 60, :verify_mode => OpenSSL::SSL::VERIFY_NONE})
-      options[:timeout] ||= 60
+    def create_connection(options = {:timeout => 10, :verify_mode => OpenSSL::SSL::VERIFY_NONE})
+      options[:timeout] ||= 10
       connection = Net::HTTP.new(self.host, self.port)
       connection.read_timeout = options[:timeout]
       if self.https?


### PR DESCRIPTION
The default wrest timeout configuration of 60 seconds is quite high. This changes the default configuration to 10 seconds instead.
