### PR TITLE
Revert "Apply query string escaping". 

### DIFF
--- a/lib/wrest/uri.rb
+++ b/lib/wrest/uri.rb
@@ -39,7 +39,7 @@ module Wrest #:nodoc:
     # See Wrest::Native::Request for other available options and their default values.
     def initialize(uri_string, options = {})
       @options = options.clone
-      @uri_string = URI.escape(uri_string.to_s)
+      @uri_string = uri_string.to_s
       @uri = URI.parse(@uri_string)
       uri_scheme = URI.split(@uri_string)
       @uri_path = uri_scheme[-4].split('?').first || ''

--- a/spec/wrest/uri_spec.rb
+++ b/spec/wrest/uri_spec.rb
@@ -108,10 +108,6 @@ module Wrest
       Uri.new('http://foo:bar@localhost:3000').to_s.should == 'http://foo:bar@localhost:3000'
     end
 
-    it "should escape query parameters" do
-      Uri.new('http://localhost:3000/search?q=stuff to search for&bar=something').full_path.should == '/search?q=stuff%20to%20search%20for&bar=something'
-    end
-
     describe 'Equals' do
       it "should understand equality" do
         Uri.new('https://localhost:3000/ooga').should_not == nil


### PR DESCRIPTION
Make sure param are escaped correctly before they get added to url

This reverts commit 256755bf7985029e9d31c302f834ffe55f90b043 (part of #3)