### PR TITLE
fix build request in case params empty

### DIFF
--- a/lib/wrest/native/request.rb
+++ b/lib/wrest/native/request.rb
@@ -122,7 +122,7 @@ module Wrest::Native
     end
 
     #:nodoc:
-    def build_request(request_klass, uri, parameters, headers)
+    def build_request(request_klass, uri, parameters = {}, headers = {})
       if(!uri.query.empty?)
         request_klass.new(parameters.empty? ? "#{uri.uri_path}?#{uri.query}" : "#{uri.uri_path}?#{uri.query}&#{parameters.to_query}", headers)
       else


### PR DESCRIPTION
https://tickets.vivino.com/issues/39515

A fix for:
```
/Users/dgaviuk/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/activesupport-5.2.4.3/lib/active_support/core_ext/object/to_query.rb:13:in `to_query'
/Users/dgaviuk/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/bundler/gems/wrest-09af9830c5fc/lib/wrest/native/request.rb:127:in `build_request'
/Users/dgaviuk/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/bundler/gems/wrest-09af9830c5fc/lib/wrest/native/request.rb:57:in `initialize'
/Users/dgaviuk/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/bundler/gems/wrest-09af9830c5fc/lib/wrest/native/delete.rb:13:in `initialize'
/Users/dgaviuk/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/bundler/gems/wrest-09af9830c5fc/lib/wrest/uri.rb:138:in `new'
/Users/dgaviuk/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/bundler/gems/wrest-09af9830c5fc/lib/wrest/uri.rb:138:in `build_delete'
/Users/dgaviuk/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/bundler/gems/wrest-09af9830c5fc/lib/wrest/uri.rb:245:in `delete'
/Users/dgaviuk/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/bundler/gems/ruby-lib-api-a548f0f2e7b6/lib/vivino_api/models/base.rb:33:in `process_delete'
/Users/dgaviuk/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/bundler/gems/ruby-lib-api-a548f0f2e7b6/lib/vivino_api/models/manual_matching_queue.rb:40:in `remove'
/Users/dgaviuk/ruby/ruby-manage-ui/app/controllers/tier/labels_controller.rb:77:in `update'
```