### PR TITLE
Handle Dalli runtime exceptions as a cache miss

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ end
 
 group :libxml do
   platforms :ruby do
-    gem 'libxml-ruby', '~> 2.8.0' unless Object.const_defined?('RUBY_ENGINE') && RUBY_ENGINE =~ /rbx/
+    gem 'libxml-ruby', '~> 3.0.0' unless Object.const_defined?('RUBY_ENGINE') && RUBY_ENGINE =~ /rbx/
   end
 end
 

--- a/lib/wrest/caching/memcached.rb
+++ b/lib/wrest/caching/memcached.rb
@@ -15,20 +15,35 @@ module Wrest::Caching
     end
 
     def [](key)
-      @memcached.get(key)
+      begin
+        @memcached.get(key)
+      rescue Dalli::DalliError => e
+        Wrest.logger.error "Error reading #{key} from cache: #{e.inspect}"
+        return nil
+      end
     end
 
     def []=(key, value)
-      @memcached.set(key, value)
+      begin
+        @memcached.set(key, value)
+      rescue Dalli::DalliError => e
+        Wrest.logger.error "Error writing #{key} to cache: #{e.inspect}"
+        return nil
+      end
     end
 
     # should be compatible with Hash - return value of the deleted element.
     def delete(key)
-      value = self[key]
-      
-      @memcached.delete key
+      begin
+        value = self[key]
 
-      return value
+        @memcached.delete key
+
+        return value
+      rescue Dalli::DalliError => e
+        Wrest.logger.error "Error deleting #{key} from cache: #{e.inspect}"
+        return nil
+      end
     end
   end
 end

--- a/spec/wrest/caching/memcached_spec.rb
+++ b/spec/wrest/caching/memcached_spec.rb
@@ -16,7 +16,7 @@ describe Wrest::Caching do
         Dalli::Client.should_receive(:new).with(nil, {})
         client = Wrest::Caching::Memcached.new
       end
-      
+
       it "should always default the options to an empty hash" do
         Dalli::Client.should_receive(:new).with(nil, {})
         client = Wrest::Caching::Memcached.new
@@ -35,6 +35,39 @@ describe Wrest::Caching do
     it "should know how to delete a cache entry" do
       @memcached.delete("abc").should == "xyz"
       expect(@memcached["abc"]).to eq(nil)
+    end
+
+    context "when a Dalli runtime exception is thrown" do
+      before :each do
+        allow_any_instance_of(Dalli::Client)
+          .to receive(:get)
+          .and_raise(Dalli::RingError, 'No server available')
+
+        allow_any_instance_of(Dalli::Client)
+          .to receive(:set)
+          .and_raise(Dalli::RingError, 'No server available')
+
+        allow_any_instance_of(Dalli::Client)
+          .to receive(:delete)
+          .and_raise(Dalli::RingError, 'No server available')
+
+        @failing_memcached = Wrest::Caching::Memcached.new
+      end
+
+      it "should treat get as a cache miss" do
+        @failing_memcached = Wrest::Caching::Memcached.new
+        expect(@failing_memcached["abc"]).to eq(nil)
+      end
+
+      it "should treat put as a cache miss" do
+        @failing_memcached["abc"] = "123"
+        expect(@failing_memcached["abc"]).to eq(nil)
+      end
+
+      it "should treat delete as a cache miss" do
+        @failing_memcached.delete("abc").should == nil
+        expect(@failing_memcached["abc"]).to eq(nil)
+      end
     end
   end
 end


### PR DESCRIPTION
Ticket reference: [#40893](https://tickets.vivino.com/issues/40893)

## How did you implement this?

- catch all Dalli::DalliError runtime errors
- log the error
- return nil when an error is encountered (it treated like a cache miss)

## How did you check this works as expected?

- set up ruby-web with the new wrest version
- configured it locally to run with a local memcached instance and made sure the server is not running
- when loading a vivino page, I could notice the errors in the logs but everything was still working as expected