### PR TITLE
fix(uri): escape before parsing to avoid uri invalid error

### DIFF
--- a/lib/wrest/uri.rb
+++ b/lib/wrest/uri.rb
@@ -39,7 +39,7 @@ module Wrest #:nodoc:
     # See Wrest::Native::Request for other available options and their default values.
     def initialize(uri_string, options = {})
       @options = options.clone
-      @uri_string = uri_string.to_s
+      @uri_string = CGI.escape(uri_string.to_s.strip)
       @uri = URI.parse(@uri_string)
       uri_scheme = URI.split(@uri_string)
       @uri_path = uri_scheme[-4].split('?').first || ''


### PR DESCRIPTION
On ruby web we are getting a lot of errors in sentry due to invalid characters in the URI https://sentry.io/organizations/vivino-com/issues/3226199865/?project=163490&query=is%3Aunresolved+level%3Aerror

This can be fixed by escaping the uri string before parsing it. It seems like we used to do this with `URI.escape`, but it was reverted here: https://github.com/Vivino/wrest/pull/8.

As I understand it seems like the revert happened since `URI.escape` was removed since it was deprecated in part of upgrading to 2.1.4 in here https://github.com/Vivino/wrest/pull/3.

~~This PR aims to redo the escaping, but instead using the not deprecated `CGI.escape`~~
The `CGI.escape` will not work since it is escaping the whole url, including the path slashes, seems like it is very hard to escape a full uri string, with a single method. Investigating a bit further.