### PR TITLE
chore(dalli): update version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :libxml do
 end
 
 group :memcached_support do
-  gem 'dalli', '3.2.1'
+  gem 'dalli', '>=2', '<=3.2.2'
 end
 
 group :redis_support do

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :libxml do
 end
 
 group :memcached_support do
-  gem 'dalli', '~> 2'
+  gem 'dalli', '3.2.1'
 end
 
 group :redis_support do

--- a/lib/wrest/caching/memcached.rb
+++ b/lib/wrest/caching/memcached.rb
@@ -1,7 +1,7 @@
 begin
-  gem 'dalli', '<=3.2.1', '>=2'
+  gem 'dalli', '>=2', '<=3.2.2'
 rescue Gem::LoadError => e
-  Wrest.logger.debug "Matching Dalli version not found must be between 2 an 3.2.1. The Dalli gem is necessary to use the memcached caching back-end."
+  Wrest.logger.debug "Matching Dalli version not found must be between 2 an 3.2.2. The Dalli gem is necessary to use the memcached caching back-end."
   raise e
 end
 

--- a/lib/wrest/caching/memcached.rb
+++ b/lib/wrest/caching/memcached.rb
@@ -1,7 +1,7 @@
 begin
-  gem 'dalli', '3.2.1'
+  gem 'dalli', '<=3.2.1', '>=2'
 rescue Gem::LoadError => e
-  Wrest.logger.debug "Dalli ~> 3.2.1 not found. The Dalli gem is necessary to use the memcached caching back-end."
+  Wrest.logger.debug "Matching Dalli version not found must be between 2 an 3.2.1. The Dalli gem is necessary to use the memcached caching back-end."
   raise e
 end
 

--- a/lib/wrest/caching/memcached.rb
+++ b/lib/wrest/caching/memcached.rb
@@ -1,7 +1,7 @@
 begin
   gem 'dalli', '3.2.1'
 rescue Gem::LoadError => e
-  Wrest.logger.debug "Dalli ~> 2 not found. The Dalli gem is necessary to use the memcached caching back-end."
+  Wrest.logger.debug "Dalli ~> 3.2.1 not found. The Dalli gem is necessary to use the memcached caching back-end."
   raise e
 end
 

--- a/lib/wrest/caching/memcached.rb
+++ b/lib/wrest/caching/memcached.rb
@@ -1,5 +1,5 @@
 begin
-  gem 'dalli', '~> 2'
+  gem 'dalli', '3.2.1'
 rescue Gem::LoadError => e
   Wrest.logger.debug "Dalli ~> 2 not found. The Dalli gem is necessary to use the memcached caching back-end."
   raise e


### PR DESCRIPTION
When upgrading to Rails 6 on ruby-web, the `dalli-elasticache` version was updated. The new versiosn of `dalli-elasticache` depends on a different `dalli` client version. We need to update the version to support Rails 6